### PR TITLE
fix gemspec file

### DIFF
--- a/tematica.gemspec
+++ b/tematica.gemspec
@@ -1,22 +1,20 @@
-# coding: UTF-8
-
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path('../lib', __FILE__)
 
 # Maintain your gem's version:
-require "tematica/version"
+require 'tematica/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "tematica"
+  s.name        = 'tematica'
   s.version     = Tematica::VERSION
-  s.authors     = ["Fernan2 & jguitar - Rankia"]
-  s.email       = ["fernando@rankia.com"]
-  s.homepage    = "https://github.com/Soluciones/tematica"
-  s.summary     = "Permite gestionar temáticas y asignarlas a otras clases."
-  s.description = ""
+  s.authors     = ['Fernan2 & jguitar - Rankia']
+  s.email       = ['fernando@rankia.com']
+  s.homepage    = 'https://github.com/Soluciones/tematica'
+  s.summary     = 'Permite gestionar temáticas y asignarlas a otras clases.'
+  s.description = ''
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.markdown"]
-  s.test_files = Dir["test/**/*"]
+  s.files = Dir['{app,config,db,lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', 'README.md']
+  s.test_files = Dir['test/**/*']
 
   s.add_dependency 'rails', '~> 4.1.5'
   s.add_dependency 'inherited_resources'


### PR DESCRIPTION
As an error/warning arised on Rankia, after `bundle`ing with `v4.1.2`
```
tematica at /Users/d2bit/.rvm/gems/ruby-2.1.2/bundler/gems/tematica-cdb196ff8b09 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["README.markdown"] are not files
```

* README.markdown -> README.md
* clean doble-quotes